### PR TITLE
Update for iOS builds and test devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Add ```io.flutter.embedded_views_preview``` in info.plist
 <true/>
 ```
 
+Follow any additional instructions found here
+
+[Google Ad Manager Getting Started Guide](https://developers.google.com/ad-manager/mobile-ads-sdk/ios/quick-start#update_your_infoplist)
+
 ### Android
 
 Add ```com.google.android.gms.ads.AD_MANAGER_APP``` in AndroidManifest.xml
@@ -29,6 +33,9 @@ Add ```com.google.android.gms.ads.AD_MANAGER_APP``` in AndroidManifest.xml
     </application>
 </manifest>
 ```
+Follow any additional instructions found here
+
+[Google Ad Manager Getting Started Guide](https://developers.google.com/ad-manager/mobile-ads-sdk/android/quick-start#update_your_androidmanifestxml)
 
 # Banner Ads
 
@@ -38,7 +45,7 @@ Just write the ```DFPBanner``` widget in your favorite place.
 DFPBanner(
   isDevelop: true,
   testDevices: MyTestDevices(),
-  adUnitId: 'XXXXXXXXX/XXXXXXXXX',
+  adUnitId: '/XXXXXXXXX/XXXXXXXXX',
   adSize: DFPAdSize.BANNER,
   onAdLoaded: () {
     print('Banner onAdLoaded');

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -43,5 +43,7 @@
 	<false/>
     <key>io.flutter.embedded_views_preview</key>
     <true/>
+    <key>GADIsAdManagerApp</key>
+    <true/>
 </dict>
 </plist>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -131,7 +131,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   child: DFPBanner(
                     isDevelop: true,
                     testDevices: MyTestDevices(),
-                    adUnitId: 'XXXXXXXXX/XXXXXXXXX',
+                    adUnitId: '/XXXXXXXXX/XXXXXXXXX',
                     adSize: DFPAdSize.BANNER,
                     onAdLoaded: () {
                       print('Banner onAdLoaded');

--- a/ios/Classes/InterstitialAd.swift
+++ b/ios/Classes/InterstitialAd.swift
@@ -81,7 +81,7 @@ extension InterstitialAd: GADInterstitialDelegate {
 
     /// Tells the delegate the interstitial is to be animated off the screen.
     func interstitialWillDismissScreen(_ ad: DFPInterstitial) {
-        interstitialAd = DFPInterstitial(adUnitID: ad.adUnitID)
+        interstitialAd = DFPInterstitial(adUnitID: ad.adUnitID!)
         interstitialAd?.delegate = self
     }
 

--- a/lib/banner.dart
+++ b/lib/banner.dart
@@ -115,6 +115,7 @@ class _DFPBannerViewState extends State<_DFPBannerView> {
     }
     widget.onPlatformCompleted(_DFPBannerViewController(
       isDevelop: widget.isDevelop,
+      testDevices: widget.testDevices,
       adUnitId: widget.adUnitId,
       adSize: widget.adSize,
       onAdLoaded: widget.onAdLoaded,


### PR DESCRIPTION
Update README.md with additional instructions from the Ad Manager getting started guide and format of the adUnitID to show a ‘/‘ at the beginning
Add GADIsAdManagerApp section to the Info.plist as per the getting started guide
Update example adUnitID to show a ‘/‘ at the beginning
Fix iOS compile issue in creating the DFPInterstitial
Update banner.dart to pass in testDevices to the DFPBannerViewController