### PR TITLE
Make DFPBanner to StatefulWidget for reload

### DIFF
--- a/lib/banner.dart
+++ b/lib/banner.dart
@@ -206,33 +206,33 @@ class DFPBannerViewController {
 
   final MethodChannel _channel;
 
-  Future<void> _init() async {
-    _channel.setMethodCallHandler((call) {
-      switch (call.method) {
-        case "onAdLoaded":
-          onAdLoaded();
-          break;
-        case "onAdFailedToLoad":
-          var map = call.arguments.cast<String, int>();
-          onAdFailedToLoad(map['errorCode']);
-          break;
-        case "onAdOpened":
-          onAdOpened();
-          break;
-        case "onAdClosed":
-          onAdClosed();
-          break;
-        case "onAdLeftApplication":
-          onAdLeftApplication();
-          break;
-      }
-      return Future.value(null);
-    });
-
+  Future<void> _init() {
+    _channel.setMethodCallHandler(_handler);
     return _load();
   }
 
-  Future<void> reload() async {
+  Future<void> _handler(MethodCall call) {
+    switch (call.method) {
+      case "onAdLoaded":
+        onAdLoaded();
+        break;
+      case "onAdFailedToLoad":
+        var map = call.arguments.cast<String, int>();
+        onAdFailedToLoad(map['errorCode']);
+        break;
+      case "onAdOpened":
+        onAdOpened();
+        break;
+      case "onAdClosed":
+        onAdClosed();
+        break;
+      case "onAdLeftApplication":
+        onAdLeftApplication();
+        break;
+    }
+  }
+
+  Future<void> reload() {
     return _load();
   }
 

--- a/lib/banner.dart
+++ b/lib/banner.dart
@@ -202,7 +202,7 @@ class DFPBannerViewController {
     this.onAdViewCreated,
     this.customTargeting,
     int id,
-  }) : _channel = new MethodChannel('plugins.ko2ic.com/google_ad_manager/banner/$id');
+  }) : _channel = MethodChannel('plugins.ko2ic.com/google_ad_manager/banner/$id');
 
   final MethodChannel _channel;
 


### PR DESCRIPTION
Changed DFPBanner to StatefulWidget to hold the DFPBannerViewController, which allows reload the banner from outside.

This Pull-request allows code like:

```dart
class _YourWidgetState extends State<_HomeHeader> {
  final GlobalKey<DFPBannerState> bannerKey = GlobalKey<DFPBannerState>();

  @override
  Widget build(BuildContext context) {
    return Column(
      children: <Widget>[
        DFPBanner(
          key: bannerKey,
          isDevelop: isDevelop,
          adUnitId: '/your-unit-id',
          adSize: DFPAdSize.BANNER,
        ),
        RaisedButton(
          onPressed: () => bannerKey.currentState?.reload(),
          child: const Text('Reload the Ad'),
        ),
      ],
    );
  }
}
```
