### PR TITLE
Hotfix/onRewaded does not work on iOS

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -79,7 +79,7 @@ class _MyHomePageState extends State<MyHomePage> {
       onAdLeftApplication: () {
         print('rewardedAd onAdLeftApplication');
       },
-      onRewarded: (String type, int amount) {
+      onRewarded: (String type, double amount) {
         print('rewardedAd onRewarded: type:$type amount:$amount');
       },
       onVideoStarted: () {

--- a/ios/Classes/RewardedAd.swift
+++ b/ios/Classes/RewardedAd.swift
@@ -64,7 +64,7 @@ class RewardedAd: SwiftFlutterGoogleAdManagerPlugin {
 extension RewardedAd: GADRewardBasedVideoAdDelegate {
     func rewardBasedVideoAd(_: GADRewardBasedVideoAd,
                             didRewardUserWith reward: GADAdReward) {
-        channel.invokeMethod("onRewarded", arguments: ["yype": reward.type, "amount": reward.amount])
+        channel.invokeMethod("onRewarded", arguments: ["type": reward.type, "amount": reward.amount])
     }
 
     func rewardBasedVideoAdDidReceive(_: GADRewardBasedVideoAd) {

--- a/lib/rewarded_ad.dart
+++ b/lib/rewarded_ad.dart
@@ -13,7 +13,7 @@ class DFPRewardedAd {
   final void Function() onAdOpened;
   final void Function() onAdClosed;
   final void Function() onAdLeftApplication;
-  final void Function(String type, int amount) onRewarded;
+  final void Function(String type, double amount) onRewarded;
   final void Function() onVideoStarted;
   final void Function() onVideoCompleted;
 
@@ -52,7 +52,7 @@ class DFPRewardedAd {
         break;
       case 'onRewarded':
         var type = call.arguments['type'] as String;
-        var amount = call.arguments['amount'] as int;
+        var amount = call.arguments['amount'] as double;
         this.onRewarded(type, amount);
         break;
       case 'onVideoStarted':


### PR DESCRIPTION
## Overview

Fixed an error in the "onRewarded" callback function on iOS.

## Modifications
- A typo in the "type" key in the native code ( `"yype" -> "type"` )

    - ios > Classes > RewardedAd.swift

        ```swift
        func rewardBasedVideoAd(_: GADRewardBasedVideoAd,
                                didRewardUserWith reward: GADAdReward) {
            // before
            channel.invokeMethod("onRewarded", arguments: ["yype": reward.type, "amount": reward.amount])
            // after
            channel.invokeMethod("onRewarded", arguments: ["type": reward.type, "amount": reward.amount])
        }
        ```
- Invalid cast error ( `type 'double' is not a subtype of type 'int' in type cast` )

    - lib > rewarded_ad.dart
        ```dart
        // before
        final void Function(String type, int amount) onRewarded;
        // after
        final void Function(String type, double amount) onRewarded;

            :
            :
            
        case 'onRewarded':
            var type = call.arguments['type'] as String;
            // before
            var amount = call.arguments['amount'] as int;
            // after
            var amount = call.arguments['amount'] as double;
            this.onRewarded(type, amount);
            break;
        ```

    - example > lib > main.dart

        ```dart
        // before
        onRewarded: (String type, int amount) {
        // after
        onRewarded: (String type, double amount) {
            print('rewardedAd onRewarded: type:$type amount:$amount');
        },
        ```